### PR TITLE
Make contributing and changelog files from readme.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,24 @@
 # Contributing
 
-This site is now a [Jekyll](http://jekyllrb.com/) site, which is automatically compiled via [GitHub Pages](https://pages.github.com).
+## About this site
 
-- It now contains some modularity, namely:
-  - the html files in `_layouts/`
-  - the html files in `_includes/`
-  - the data files in `_data/`
-  - the front matter metadata in `pages/*.md`
-- Some atomic css was brought in for the purposes of quickly scaffolding out an updated site (as well as better css organization, but that's another story). See the comment toward the middle of `css/custom.css` for more info.
-- To update the hackathon products or upcoming hackathon dates, edit the files in `_data/`.
-- Possible workflows for updating this site:
-  - via GitHub.com in a web browser
-  - via a text editor on a computer with a git connection to the remote repo
-  - via a computer with jekyll and git, etc.
+This site is a [Jekyll](http://jekyllrb.com/) site, which is built and hosted via [GitHub Pages](https://pages.github.com).
 
-**Questions/problems?**
-Contact @brianzelip
+It contains some modularity, namely:
+
+- the html files in `_layouts/`
+- the html files in `_includes/`
+- the data files in `_data/`
+- the front matter metadata in `pages/*.md`
+
+To update the hackathon products or upcoming hackathon dates, edit the files in `_data/`.
+
+Possible workflows for updating this site:
+
+- via GitHub.com in a web browser
+- via a text editor on a computer with a git connection to the remote repo
+- via a computer with jekyll and git, etc.
+
+## Questions/problems?
+
+Contact [@brianzelip](https://github.com/brianzelip)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+This site is now a [Jekyll](http://jekyllrb.com/) site, which is automatically compiled via [GitHub Pages](https://pages.github.com).
+
+- It now contains some modularity, namely:
+  - the html files in `_layouts/`
+  - the html files in `_includes/`
+  - the data files in `_data/`
+  - the front matter metadata in `pages/*.md`
+- Some atomic css was brought in for the purposes of quickly scaffolding out an updated site (as well as better css organization, but that's another story). See the comment toward the middle of `css/custom.css` for more info.
+- To update the hackathon products or upcoming hackathon dates, edit the files in `_data/`.
+- Possible workflows for updating this site:
+  - via GitHub.com in a web browser
+  - via a text editor on a computer with a git connection to the remote repo
+  - via a computer with jekyll and git, etc.
+
+**Questions/problems?**
+Contact @brianzelip

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-# Biohackathons Github Page!
+# Biohackathons
 
 https://biohackathons.github.io/
+
+Bringing people together to build tools or perform advanced bioinformatics analysis.
+
+See [our about page](https://biohackathons.github.io/About.html) for more info.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 https://biohackathons.github.io/
 
 ---
-**Changelog**
-- Ben Busby migrated this site to be an international biohackathons site during the 2018 GCC/BOSC hackathon
-- Brian Zelip updated this site during the June 19-21, 2017 NYGC Hackathon.
+
 - This site is now a [Jekyll](http://jekyllrb.com/) site, which is automatically compiled via [GitHub Pages](https://pages.github.com).
 - It now contains some modularity, namely:
   - the html files in `_layouts/`

--- a/README.md
+++ b/README.md
@@ -1,23 +1,3 @@
 # Biohackathons Github Page!
 
 https://biohackathons.github.io/
-
----
-
-- This site is now a [Jekyll](http://jekyllrb.com/) site, which is automatically compiled via [GitHub Pages](https://pages.github.com).
-- It now contains some modularity, namely:
-  - the html files in `_layouts/`
-  - the html files in `_includes/`
-  - the data files in `_data/`
-  - the front matter metadata in `pages/*.md`
-- Some atomic css was brought in for the purposes of quickly scaffolding out an updated site (as well as better css organization, but that's another story). See the comment toward the middle of `css/custom.css` for more info.
-- To update the hackathon products or upcoming hackathon dates, edit the files in `_data/`.
-- Possible workflows for updating this site:
-  - via GitHub.com in a web browser
-  - via a text editor on a computer with a git connection to the remote repo
-  - via a computer with jekyll and git, etc.
-
-**Questions/problems?**
-Contact @brianzelip
-
-Integration test

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format **is not yet** based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project **does not yet** adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+- Ben Busby migrated this site to be an international biohackathons site during the 2018 GCC/BOSC hackathon
+
+- Brian Zelip updated this site during the June 19-21, 2017 NYGC Hackathon.

--- a/changelog.md
+++ b/changelog.md
@@ -10,3 +10,5 @@ and this project **does not yet** adhere to [Semantic Versioning](https://semver
 - Ben Busby migrated this site to be an international biohackathons site during the 2018 GCC/BOSC hackathon
 
 - Brian Zelip updated this site during the June 19-21, 2017 NYGC Hackathon.
+  - ported the site to a jekyll site
+  - Added an atomic css approach for the purposes of quickly scaffolding out an updated site (as well as better css organization, but that's another story). See the comment toward the middle of `css/custom.css` for more info.


### PR DESCRIPTION
This PR translates the text from README.md that had to do with docs on how to contribute to the site, and changelog info into new files.

Closes #25 