### PR TITLE
Add new hackathons and sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@
 .Ruserdata
 _site/*
 *cache
+
+# Jekyll specific
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+vendor/
+.bundle/
+Gemfile.lock
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "jekyll"
+gem "webrick" # Required for Ruby >= 3.0
+
+# If you have any Jekyll plugins, add them here
+gem "jekyll-sitemap"

--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,5 @@ title: "biohackathons"
 # Use a Google Font
 font: "Public Sans" # Can also be 'Ubuntu', 'Public Sans', 'Source Sans Pro', or 'Oswald'
 
+plugins:
+  - jekyll-sitemap

--- a/_data/upcoming_hackathons.yml
+++ b/_data/upcoming_hackathons.yml
@@ -8,9 +8,19 @@
   link: https://www.open-bio.org/events/bosc-2025/ismb-collaborationfest-2025/
   community:  
 
-- date: "September 8-12, 2025"
-  loc: "NCBI Comparative Genomics Codeathon: Advancing human health through collaborative discovery"
-  link: https://ncbiinsights.ncbi.nlm.nih.gov/event/2025cgcodeathon/
+- date: "August 14-15, 2025"
+  loc: "Cell Maps for AI CodeFest"
+  link: https://www.uab.edu/medicine/informatics/news-events/events/cm4ai-codefest-at-uab
+  community:
+
+- date: "August 27-29, 2025"
+  loc: "SV Hackathon 2025"
+  link: https://fritzsedlazeck.github.io/blog/2025/hackathon-2025/
+  community:
+
+- date: "September 29 - October 1, 2025"
+  loc: "St. Jude KIDS25 (Knowledge in Data Science) BioHackathon"
+  link: https://www.stjude.org/research/why-st-jude/biohackathon.html
   community:
 
 - date: "October 1-3, 2025"
@@ -21,4 +31,9 @@
 - date: "October 21-22, 2025"
   loc: "Open Targets Hackathon"
   link: https://www.opentargets.org/hackathon
+  community:
+
+- date: "November 3-7, 2025"
+  loc: "BioHackathon Europe"
+  link: https://biohackathon-europe.org/
   community:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,22 +1,28 @@
 <head>
-    <meta charset="UTF-8">
-    <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-    <link href="/css/custom.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Oswald|Source+Sans+Pro|Ubuntu|Public+Sans" rel="stylesheet">
-    <script src="/js/jquery.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
-    <title>{{ site.title }}
-        {% if page.title %}
-            -
-            {{ page.title }}
-        {% endif %}
-    </title>
-    <style>
-    body, html, div, p, a, h1, h2, h3, h4, h5, h6, footer, form {
-  font-family: "{{ site.font }}", sans-serif;
-}
+  <meta charset="UTF-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
+  
+  <!-- SEO enhancements -->
+  <meta name="description" content="Bringing people together to build tools or perform advanced bioinformatics analysis.">
+  <meta name="robots" content="index, follow">
+
+  <link href="/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/css/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+
+  <link href="https://fonts.googleapis.com/css?family=Oswald|Source+Sans+Pro|Ubuntu|Public+Sans" rel="stylesheet">
+  <script src="/js/jquery.js"></script>
+  <script src="/js/bootstrap.min.js"></script>
+  <title>{{ site.title }}
+      {% if page.title %}
+          -
+          {{ page.title }}
+      {% endif %}
+  </title>
+  <style>
+  body, html, div, p, a, h1, h2, h3, h4, h5, h6, footer, form {
+    font-family: "{{ site.font }}", sans-serif;
+  }
   </style>
 </head>

--- a/css/custom.css
+++ b/css/custom.css
@@ -390,3 +390,8 @@ h6 {
     background-color: #225077;
     border-color: #020029;
 }
+
+body {
+    font-size: 16px;
+    line-height: 1.5;
+}

--- a/pages/About.md
+++ b/pages/About.md
@@ -5,21 +5,21 @@ permalink: /About.html
 ---
 # About
 
-###### See the bottom of this page for hackathon styles employed in the Biological/Biomedical Data Science Space.
+See the bottom of this page for hackathon styles employed in the Biological/Biomedical Data Science Space.
 
 ## Goal
 
-###### Bringing people together to build tools to or perform advanced bioinformatics analysis.
+Bringing people together to build tools to or perform advanced bioinformatics analysis.
 
 ## Products
 
-###### Some pipelines and other scripts, software and programs generated in the events will be added to public GitHub repositories designed for that purpose.
+- Some pipelines and other scripts, software and programs generated in the events will be added to public GitHub repositories designed for that purpose.
 
-###### A manuscript outlining the design and usage of the software tools constructed by each team may be submitted to an appropriate journal, such as the F1000Research Hackathons channel.
+- A manuscript outlining the design and usage of the software tools constructed by each team may be submitted to an appropriate journal, such as the F1000Research Hackathons channel.
 
 ## Notes
 
-###### Typically, participants will need to bring their own laptop to these programs.
+Typically, participants will need to bring their own laptop to these programs.
 
 ## Hackathon styles employed by various institutions
 

--- a/pages/Contact.md
+++ b/pages/Contact.md
@@ -4,7 +4,6 @@ title: Contact
 permalink: /Contact.html
 ---
 
-# Contact
+# Contact Us
 
-##### [biohackathons@gmail.com](mailto:biohackathons@gmail.com)
-##### [ben.busby@gmail.com](mailto:ben.busby@gmail.com)
+For questions about biohackathons or to get involved, please reach out to [biohackathons@gmail.com](mailto:biohackathons@gmail.com) or [ben.busby@gmail.com](mailto:ben.busby@gmail.com).

--- a/pages/Help.md
+++ b/pages/Help.md
@@ -6,7 +6,6 @@ permalink: /Help.html
 
 # Help
 
-
-##### For help with this page, please see the [about](/About.html) section of this website, or [contact Ben Busby](mailto:ben.busby@gmail.com).  
-
-##### For help with applying to particular hackathons, please contact the organizers of the individual events, listed on their webpages.  
+- For general information, see our [About](/About.html) page.
+- For website issues, contact [ben.busby@gmail.com](mailto:ben.busby@gmail.com).
+- For specific hackathon questions, contact the event organizers listed on their respective pages.

--- a/pages/Resources.md
+++ b/pages/Resources.md
@@ -6,10 +6,7 @@ permalink: /Resources.html
 
 # Resources
 
-##### <a href="http://biohackathon.org/">Link to Biohackathons Website</a>
-
-##### <a href="https://tess.elixir-europe.org/search?utf8=%E2%9C%93&q=hackathon">Link to Hackathons on Elixir TESS</a>
-
-##### <a href="https://github.com/NCBI-Hackathons">Link to main Github Repo for NCBI Hackathons</a>
-
-##### <a href="https://f1000research.com/search?q=hackathons">Link to F1000 Research Hackathons Page</a>
+- [Biohackathons Website](http://biohackathon.org/)
+- [Hackathons on ELIXIR TESS](https://tess.elixir-europe.org/search?utf8=%E2%9C%93&q=hackathon)
+- [NCBI Hackathons GitHub](https://github.com/NCBI-Hackathons)
+- [F1000 Research Hackathons](https://f1000research.com/search?q=hackathons)


### PR DESCRIPTION
- Added `jekyll-sitemap` plugin and Gemfile for local builds and SEO
- Updated `_config.yml` and `head.html` to support sitemap and improve metadata
- Cleaned up `.gitignore` to avoid committing site cache and vendor junk
- Added and updated multiple hackathon listings in `_data/upcoming_hackathons.yml`
- Light content edits for About, Contact, Help, and Resources pages
- Minor typography tweaks (body font size, line height) in `custom.css`